### PR TITLE
Change apikey to use credentials

### DIFF
--- a/Packs/HelloWorldPremium/Integrations/HelloWorldPremium/HelloWorldPremium.py
+++ b/Packs/HelloWorldPremium/Integrations/HelloWorldPremium/HelloWorldPremium.py
@@ -1430,8 +1430,7 @@ def main() -> None:
     :return:
     :rtype:
     """
-
-    api_key = demisto.params().get('apikey')
+    api_key = demisto.get(demisto.params(), 'credentials.password')
 
     # get the service API url
     base_url = urljoin(demisto.params()['url'], '/api/v1')

--- a/Packs/HelloWorldPremium/Integrations/HelloWorldPremium/HelloWorldPremium.yml
+++ b/Packs/HelloWorldPremium/Integrations/HelloWorldPremium/HelloWorldPremium.yml
@@ -21,10 +21,11 @@ configuration:
   name: max_fetch
   required: false
   type: 0
-- display: API Key
-  name: apikey
+- displaypassword: API Key
+  name: credentials
+  type: 9
   required: true
-  type: 4
+  hiddenusername: true
 - defaultvalue: '65'
   display: Score threshold for IP reputation command
   additionalinfo: Set this to determine the HelloWorldPremium score that will determine


### PR DESCRIPTION
Change `apikey` to use credentials instead of encrypted (type 4 to type 9)

fixes: https://github.com/demisto/etc/issues/44172